### PR TITLE
Payment Service Crash(Iteration 2.0)

### DIFF
--- a/Sources/SwiftyStoreKit/ProductsInfoController.swift
+++ b/Sources/SwiftyStoreKit/ProductsInfoController.swift
@@ -53,39 +53,30 @@ class ProductsInfoController: NSObject {
     private let requestsQueue = DispatchQueue(label: "inflightRequestsQueue", attributes: .concurrent)
 
     @discardableResult
-    func retrieveProductsInfo(_ productIds: Set<String>, completion: @escaping (RetrieveResults) -> Void) -> InAppProductRequest {
-        var returnedRequest: InAppProductRequest!
+    func retrieveProductsInfo(
+        _ productIds: Set<String>,
+        completion: @escaping (RetrieveResults) -> Void
+    ) -> InAppProductRequest {
         
-        requestsQueue.sync(flags: .barrier) {
+        return requestsQueue.sync(flags: .barrier) {
             if inflightRequestsStorage[productIds] == nil {
-                // No existing request → create new
                 let request = inAppProductRequestBuilder.request(productIds: productIds) { results in
-                    self.requestsQueue.sync(flags: .barrier) {
-                        if let query = self.inflightRequestsStorage[productIds] {
-                            for completion in query.completionHandlers {
-                                completion(results)
-                            }
-                            self.inflightRequestsStorage[productIds] = nil
-                        } else {
-                            // should not get here, but if it does it seems reasonable to call the outer completion block
-                            completion(results)
-                        }
+                    self.requestsQueue.async(flags: .barrier) {
+                        guard let query = self.inflightRequestsStorage[productIds] else { return }
+                        query.completionHandlers.forEach { $0(results) }
+                        self.inflightRequestsStorage[productIds] = nil
                     }
                 }
-                inflightRequestsStorage[productIds] = InAppProductQuery(request: request, completionHandlers: [completion])
-                request.start()
-                returnedRequest = request
-            } else if var query = inflightRequestsStorage[productIds] {
-                query.completionHandlers.append(completion)
-                inflightRequestsStorage[productIds] = query
                 
-                if query.request.hasCompleted, let cached = query.request.cachedResults {
-                    query.completionHandlers.forEach { $0(cached) }
-                    inflightRequestsStorage[productIds] = nil
-                }
-                returnedRequest = query.request
+                inflightRequestsStorage[productIds] =
+                InAppProductQuery(request: request, completionHandlers: [completion])
+                
+                request.start()
+                return request
             }
+            
+            inflightRequestsStorage[productIds]!.completionHandlers.append(completion)
+            return inflightRequestsStorage[productIds]!.request
         }
-        return returnedRequest
     }
 }


### PR DESCRIPTION
### Description

Re-worked ProductsInfoController to eliminate the duplicate-resume crash:

1. Dropped the “early-cache” else branch that fired completions twice and triggered the double resume on the continuation.
2. Consolidated access to inflightRequestsStorage behind a single concurrent queue; StoreKit callback now updates via async(.barrier) to avoid re-entrant deadlocks.

Result: only one real StoreKit request per ID set, each completion fires exactly once, no more SWIFT TASK CONTINUATION MISUSE.

### Links
https://amomobile.atlassian.net/browse/IUM-12739